### PR TITLE
travis: build on tags too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ python:
 
 cache: pip
 
-branches:
-  only:
-    - master
-    - dev
-
 deploy:
   provider: pypi
   user: __token__


### PR DESCRIPTION
It is required to deploy substra-tools to pypi.

It has already been done on the substra repository by Clement:
https://github.com/SubstraFoundation/substra/commit/58c02d6554eca2b53c45603968a447a91ffcee67