### PR TITLE
improve logs

### DIFF
--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -250,11 +250,11 @@ def _generate_algo_cli(interface):
             output_model_path=args.output_model_path,
             output_predictions_path=args.output_predictions_path,
         )
+        utils.configure_logging(workspace.log_path, debug_mode=args.debug)
         opener_wrapper = opener.load_from_module(
             path=args.opener_path,
             workspace=workspace,
         )
-        utils.configure_logging(workspace.log_path, debug_mode=args.debug)
         return AlgoWrapper(
             interface,
             workspace=workspace,

--- a/substratools/exceptions.py
+++ b/substratools/exceptions.py
@@ -2,3 +2,7 @@
 
 class InvalidInterface(Exception):
     pass
+
+
+class EmptyInterface(InvalidInterface):
+    pass

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -199,7 +199,7 @@ def load_from_module(path=None, workspace=None):
     interface = utils.load_interface_from_module(
         'opener',
         interface_class=Opener,
-        interface_signature=REQUIRED_FUNCTIONS,
+        interface_signature=None,  # XXX does not support interface for debugging
         path=path,
     )
     return OpenerWrapper(interface, workspace=workspace)

--- a/substratools/utils.py
+++ b/substratools/utils.py
@@ -8,18 +8,28 @@ import sys
 from substratools import exceptions
 
 
-def configure_logging(path=None, debug_mode=False):
-    kwargs = {}
-    level = logging.DEBUG
-    if path and not debug_mode:
-        kwargs['filename'] = path
+logger = logging.getLogger(__name__)
 
-    logging.basicConfig(level=level, **kwargs)
 
-    if debug_mode:
-        # set root logger level in case the root logger has already handlers
-        # configured for it
-        logging.getLogger('substratools').setLevel(level)
+def configure_logging(path=None, debug_mode=True):
+    level = logging.DEBUG if debug_mode else logging.INFO
+
+    formatter = logging.Formatter('%(name)s - %(message)s')
+
+    h = logging.StreamHandler()
+    h.setLevel(level)
+    h.setFormatter(formatter)
+
+    root = logging.getLogger('substratools')
+    root.setLevel(level)
+    root.addHandler(h)
+
+    if path and debug_mode:
+        fh = logging.FileHandler(path)
+        fh.setLevel(level)
+        fh.setFormatter(formatter)
+
+        root.addHandler(h)
 
 
 def import_module(module_name, code):
@@ -43,9 +53,12 @@ def load_interface_from_module(module_name, interface_class,
                                interface_signature=None, path=None):
     if path:
         module = import_module_from_path(path, module_name)
+        logger.info(f"Module '{module_name}' loaded from path '{path}'")
     else:
         try:
             module = importlib.import_module(module_name)
+            logger.info(
+                f"Module '{module_name}' imported dynamically; module={module}")
         except ImportError:
             # XXX don't use ModuleNotFoundError for python3.5 compatibility
             raise
@@ -58,6 +71,8 @@ def load_interface_from_module(module_name, interface_class,
     # backward compatibility; accep
     if interface_signature is None:
         class_name = interface_class.__name__
+        elements = str(dir(module))
+        logger.info(f"Class '{class_name}' not found from: '{elements}'")
         raise exceptions.InvalidInterface(
             "Expecting {} subclass in {}".format(
                 class_name, module_name))

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -40,6 +40,7 @@ def get_y():
         load_from_module()
 
 
+@pytest.mark.skip(reason="not supported")
 def test_load_opener_as_module(tmp_cwd):
     script = """
 def _helper():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import sys
+
 from substratools import exceptions, Metrics
 from substratools.utils import import_module, load_interface_from_module
 
@@ -12,3 +14,21 @@ def score():
     import_module('score', code)
     with pytest.raises(exceptions.InvalidInterface):
         load_interface_from_module('score', interface_class=Metrics)
+
+
+@pytest.fixture
+def syspaths():
+    copy = sys.path[:]
+    yield sys.path
+    sys.path = copy
+
+
+def test_empty_module(tmpdir, syspaths):
+    with tmpdir.as_cwd():
+        # python allows to import an empty directoy
+        # check that the error message would be helpful for debugging purposes
+        tmpdir.mkdir("foomod")
+        syspaths.append(str(tmpdir))
+
+        with pytest.raises(exceptions.EmptyInterface):
+            load_interface_from_module('foomod', interface_class=Metrics)


### PR DESCRIPTION
- configure logs before loading opener
- add logs when importing a module dynamically
- when importing an opener support class mode only (other mode is not used)
- update log configuration: store them to file if debug mode otherwise add a StreamHandler for the substratools logger

EDIT:
- also add a proper exception if the imported module is empty. This error has been seen frequently when the opener module was not mounted properly. A proper error message will help when debugging.