### PR TITLE
Add user_models_generator option to Algo and AggregateAlgo

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,10 @@ following abstract methods:
 - `Algo.load_model()`
 - `Algo.save_model()`
 
+This class has an `use_models_generator` class property:
+- if True, models will be passed to the `train` method as a generator
+- (default) if False, models will be passed to the `train` method as a list
+
 To add an algo to the Substra Platform, the line
 `tools.algo.execute(<AlgoClass>())` must be added to the main of the algo
 python script. It defines the algo command line interface and thus enables
@@ -87,6 +91,12 @@ y_pred = a.predict(X, model)
 ```
 
 
+## use_models_generator
+bool(x) -> bool
+
+Returns True when the argument x is true, False otherwise.
+The builtins True and False are the only two instances of the class bool.
+The class bool is a subclass of the class int, and cannot be subclassed.
 ## train
 ```python
 Algo.train(self, X, y, models, rank)
@@ -101,7 +111,7 @@ __Arguments__
 
 - __X__: training data samples loaded with `Opener.get_X()`.
 - __y__: training data samples labels loaded with `Opener.get_y()`.
-- __models__: list of models loaded with `Algo.load_model()`.
+- __models__: list or generator of models loaded with `Algo.load_model()`.
 - __rank__: rank of the training task.
 
 __Returns__
@@ -386,6 +396,10 @@ following abstract methods:
 - `AggregateAlgo.load_model()`
 - `AggregateAlgo.save_model()`
 
+This class has an `use_models_generator` class property:
+- if True, models will be passed to the `aggregate` method as a generator
+- (default) if False, models will be passed to the `aggregate` method as a list
+
 To add a aggregate algo to the Substra Platform, the line
 `tools.algo.execute(<AggregateAlgoClass>())` must be added to the main of the algo
 python script. It defines the aggregate algo command line interface and thus enables
@@ -453,6 +467,12 @@ model_2 = a.load_model('./sandbox/models/model_2')
 aggregated_model = a.aggregate([model_1, model_2], 0)
 ```
 
+## use_models_generator
+bool(x) -> bool
+
+Returns True when the argument x is true, False otherwise.
+The builtins True and False are the only two instances of the class bool.
+The class bool is a subclass of the class int, and cannot be subclassed.
 ## aggregate
 ```python
 AggregateAlgo.aggregate(self, models, rank)

--- a/tests/test_aggregatealgo.py
+++ b/tests/test_aggregatealgo.py
@@ -117,25 +117,20 @@ def test_model_check(algo_class):
         wp.aggregate([])
 
 
-def test_models_generator(mocker, workdir, create_models):
+@pytest.mark.parametrize('use_models_generator,models_type', (
+    (True, types.GeneratorType),
+    (False, list),
+))
+def test_models_generator(mocker, workdir, create_models, use_models_generator, models_type):
     _, model_filenames = create_models
 
     command = ['aggregate']
     command.extend(model_filenames)
 
-    a1 = DummyAggregateAlgo()
-    mocker.patch.object(a1, 'aggregate', autospec=True, return_value={})
+    a = DummyAggregateAlgo()
+    a.use_models_generator = use_models_generator
+    mocker.patch.object(a, 'aggregate', autospec=True, return_value={})
 
-    algo.execute(a1, sysargs=command)
-    models_1 = a1.aggregate.call_args[0][0]
-    assert type(models_1) == list
-
-    a2 = DummyAggregateAlgo()
-    a2.use_models_generator = True
-    mocker.patch.object(a2, 'aggregate', autospec=True, return_value={})
-
-    algo.execute(a2, sysargs=command)
-    models_2 = a2.aggregate.call_args[0][0]
-    assert isinstance(models_2, types.GeneratorType)
-
-    assert models_1 == list(models_2)
+    algo.execute(a, sysargs=command)
+    models = a.aggregate.call_args[0][0]
+    assert isinstance(models, models_type)

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -191,25 +191,20 @@ def test_model_check(algo_class):
         wp.train([])
 
 
-def test_models_generator(mocker, workdir, create_models):
+@pytest.mark.parametrize('use_models_generator,models_type', (
+    (True, types.GeneratorType),
+    (False, list),
+))
+def test_models_generator(mocker, workdir, create_models, use_models_generator, models_type):
     _, model_filenames = create_models
 
     command = ['train']
     command.extend(model_filenames)
 
-    a1 = DummyAlgo()
-    mocker.patch.object(a1, 'train', autospec=True, return_value={})
+    a = DummyAlgo()
+    a.use_models_generator = use_models_generator
+    mocker.patch.object(a, 'train', autospec=True, return_value={})
 
-    algo.execute(a1, sysargs=command)
-    models_1 = a1.train.call_args[0][2]
-    assert type(models_1) == list
-
-    a2 = DummyAlgo()
-    a2.use_models_generator = True
-    mocker.patch.object(a2, 'train', autospec=True, return_value={})
-
-    algo.execute(a2, sysargs=command)
-    models_2 = a2.train.call_args[0][2]
-    assert isinstance(models_2, types.GeneratorType)
-
-    assert models_1 == list(models_2)
+    algo.execute(a, sysargs=command)
+    models = a.train.call_args[0][2]
+    assert isinstance(models, models_type)


### PR DESCRIPTION
Fixes #32 

Adds a `user_models_generator` that sets whether to pass models as list or as generators to the train or aggregate method.