### PR TITLE
Add the "n samples" option to fake data generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -660,10 +660,10 @@ class DummyOpener(tools.Opener):
             for folder in folders
         ]
 
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         return []  # compute random fake data
 
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         return []  # compute random fake data
 
     def save_predictions(self, y_pred, path):
@@ -727,14 +727,14 @@ __Returns__
 
 ## fake_X
 ```python
-Opener.fake_X(self, n_samples=None)
+Opener.fake_X(self, n_fake_samples=None)
 ```
 Generate a fake matrix of features for offline testing.
 
 __Arguments__
 
 
-- __n_samples__: number of samples to return, all by default
+- __n_fake_samples__: number of samples to return, all by default
 
 __Returns__
 
@@ -743,14 +743,14 @@ __Returns__
 
 ## fake_y
 ```python
-Opener.fake_y(self, n_samples=None)
+Opener.fake_y(self, n_fake_samples=None)
 ```
 Generate a fake target variable vector for offline testing.
 
 __Arguments__
 
 
-- __n_samples__: number of samples to return, all by default
+- __n_fake_samples__: number of samples to return, all by default
 
 __Returns__
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -568,7 +568,7 @@ interface.  For instance to get the metrics from fake data, run the
 following command:
 
 ```sh
-python <script_path> --fake-data --debug
+python <script_path> --fake-data --n-fake-samples 20 --debug
 ```
 
 To see all the available options for metrics commands, run:
@@ -734,7 +734,7 @@ Generate a fake matrix of features for offline testing.
 __Arguments__
 
 
-- __n_fake_samples__: number of samples to return, all by default
+- __n_samples__: number of samples to return, all by default
 
 __Returns__
 
@@ -750,7 +750,7 @@ Generate a fake target variable vector for offline testing.
 __Arguments__
 
 
-- __n_fake_samples__: number of samples to return, all by default
+- __n_samples__: number of samples to return, all by default
 
 __Returns__
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -660,10 +660,10 @@ class DummyOpener(tools.Opener):
             for folder in folders
         ]
 
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         return []  # compute random fake data
 
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         return []  # compute random fake data
 
     def save_predictions(self, y_pred, path):
@@ -727,7 +727,7 @@ __Returns__
 
 ## fake_X
 ```python
-Opener.fake_X(self, n_fake_samples=None)
+Opener.fake_X(self, n_samples=None)
 ```
 Generate a fake matrix of features for offline testing.
 
@@ -743,7 +743,7 @@ __Returns__
 
 ## fake_y
 ```python
-Opener.fake_y(self, n_fake_samples=None)
+Opener.fake_y(self, n_samples=None)
 ```
 Generate a fake target variable vector for offline testing.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -734,7 +734,7 @@ Generate a fake matrix of features for offline testing.
 __Arguments__
 
 
-- __n_samples__: number of samples to return, all by default
+- __n_samples__: number of samples to return
 
 __Returns__
 
@@ -750,7 +750,7 @@ Generate a fake target variable vector for offline testing.
 __Arguments__
 
 
-- __n_samples__: number of samples to return, all by default
+- __n_samples__: number of samples to return
 
 __Returns__
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ The algo script can be directly tested through it's command line interface.
 For instance to train an algo using fake data, run the following command:
 
 ```sh
-python <script_path> train --fake-data --debug
+python <script_path> train --fake-data --n-fake-samples 20 --debug
 ```
 
 To see all the available options for the train and predict commands, run:
@@ -239,7 +239,7 @@ The composite algo script can be directly tested through it's command line inter
 For instance to train an algo using fake data, run the following command:
 
 ```sh
-python <script_path> train --fake-data --debug
+python <script_path> train --fake-data --n-fake-samples 20 --debug
 ```
 
 To see all the available options for the train and predict commands, run:
@@ -660,10 +660,10 @@ class DummyOpener(tools.Opener):
             for folder in folders
         ]
 
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         return []  # compute random fake data
 
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         return []  # compute random fake data
 
     def save_predictions(self, y_pred, path):
@@ -727,9 +727,14 @@ __Returns__
 
 ## fake_X
 ```python
-Opener.fake_X(self)
+Opener.fake_X(self, n_samples=None)
 ```
 Generate a fake matrix of features for offline testing.
+
+__Arguments__
+
+
+- __n_samples__: number of samples to return, all by default
 
 __Returns__
 
@@ -738,9 +743,14 @@ __Returns__
 
 ## fake_y
 ```python
-Opener.fake_y(self)
+Opener.fake_y(self, n_samples=None)
 ```
 Generate a fake target variable vector for offline testing.
+
+__Arguments__
+
+
+- __n_samples__: number of samples to return, all by default
 
 __Returns__
 

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -70,7 +70,7 @@ class Algo(abc.ABC):
     For instance to train an algo using fake data, run the following command:
 
     ```sh
-    python <script_path> train --fake-data --debug
+    python <script_path> train --fake-data --n-fake-samples 20 --debug
     ```
 
     To see all the available options for the train and predict commands, run:
@@ -237,11 +237,11 @@ class AlgoWrapper(object):
             return self._load_models_as_generator(model_names)
         return self._load_models_as_list(model_names)
 
-    def train(self, model_names, rank=0, fake_data=False):
+    def train(self, model_names, rank=0, fake_data=False, n_samples=None):
         """Train method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data)
-        y = self._opener_wrapper.get_y(fake_data)
+        X = self._opener_wrapper.get_X(fake_data, n_samples)
+        y = self._opener_wrapper.get_y(fake_data, n_samples)
 
         # load models
         models = self._load_models(model_names)
@@ -260,10 +260,10 @@ class AlgoWrapper(object):
 
         return model
 
-    def predict(self, model_name, fake_data=False):
+    def predict(self, model_name, fake_data=False, n_samples=None):
         """Predict method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data)
+        X = self._opener_wrapper.get_X(fake_data, n_samples)
 
         # load models
         model = self._load_model(model_name)
@@ -307,7 +307,7 @@ def _generate_algo_cli(interface):
             help="Enable fake data mode",
         )
         _parser.add_argument(
-            '--n-fake', default=None, type=int,
+            '--n-fake-samples', default=None, type=int,
             help="Number of fake samples if fake data is used. Default to the maximum number of samples",
         )
         _parser.add_argument(
@@ -345,6 +345,7 @@ def _generate_algo_cli(interface):
             args.models,
             args.rank,
             args.fake_data,
+            args.n_fake_samples
         )
 
     parser = argparse.ArgumentParser()
@@ -366,6 +367,7 @@ def _generate_algo_cli(interface):
         algo_wrapper.predict(
             args.model,
             args.fake_data,
+            args.n_fake_samples
         )
 
     predict_parser = parsers.add_parser('predict')
@@ -439,7 +441,7 @@ class CompositeAlgo(abc.ABC):
     For instance to train an algo using fake data, run the following command:
 
     ```sh
-    python <script_path> train --fake-data --debug
+    python <script_path> train --fake-data --n-fake-samples 20 --debug
     ```
 
     To see all the available options for the train and predict commands, run:
@@ -630,11 +632,11 @@ class CompositeAlgoWrapper(AlgoWrapper):
         self._assert_output_model_exists(self._workspace.output_head_model_path, 'head')
 
     def train(self, input_head_model_filename=None, input_trunk_model_filename=None,
-              rank=0, fake_data=False):
+              rank=0, fake_data=False, n_samples=None):
         """Train method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data)
-        y = self._opener_wrapper.get_y(fake_data)
+        X = self._opener_wrapper.get_X(fake_data, n_samples)
+        y = self._opener_wrapper.get_y(fake_data, n_samples)
 
         # load head and trunk models
         head_model, trunk_model = self._load_head_trunk_models(
@@ -660,10 +662,10 @@ class CompositeAlgoWrapper(AlgoWrapper):
         return head_model, trunk_model
 
     def predict(self, input_head_model_filename, input_trunk_model_filename,
-                fake_data=False):
+                fake_data=False, n_samples=None):
         """Predict method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data)
+        X = self._opener_wrapper.get_X(fake_data, n_samples)
 
         # load head and trunk models
         head_model, trunk_model = self._load_head_trunk_models(
@@ -711,6 +713,10 @@ def _generate_composite_algo_cli(interface):
             help="Enable fake data mode",
         )
         _parser.add_argument(
+            '--n-fake-samples', default=None, type=int,
+            help="Number of fake samples if fake data is used. Default to the maximum number of samples",
+        )
+        _parser.add_argument(
             '--data-samples-path', default=None,
             help="Define train/test data samples folder path",
         )
@@ -755,6 +761,7 @@ def _generate_composite_algo_cli(interface):
             args.input_trunk_model_filename,
             args.rank,
             args.fake_data,
+            args.n_fake_samples
         )
 
     parser = argparse.ArgumentParser()
@@ -781,6 +788,7 @@ def _generate_composite_algo_cli(interface):
             args.input_head_model_filename,
             args.input_trunk_model_filename,
             args.fake_data,
+            args.n_fake_samples
         )
 
     predict_parser = parsers.add_parser('predict')

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -308,7 +308,7 @@ def _generate_algo_cli(interface):
         )
         _parser.add_argument(
             '--n-fake-samples', default=None, type=int,
-            help="Number of fake samples if fake data is used. Default to the maximum number of samples",
+            help="Number of fake samples if fake data is used.",
         )
         _parser.add_argument(
             '--data-samples-path', default=None,

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -714,7 +714,7 @@ def _generate_composite_algo_cli(interface):
         )
         _parser.add_argument(
             '--n-fake-samples', default=None, type=int,
-            help="Number of fake samples if fake data is used. Default to the maximum number of samples",
+            help="Number of fake samples if fake data is used.",
         )
         _parser.add_argument(
             '--data-samples-path', default=None,

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -237,11 +237,11 @@ class AlgoWrapper(object):
             return self._load_models_as_generator(model_names)
         return self._load_models_as_list(model_names)
 
-    def train(self, model_names, rank=0, fake_data=False, n_samples=None):
+    def train(self, model_names, rank=0, fake_data=False, n_fake_samples=None):
         """Train method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data, n_samples)
-        y = self._opener_wrapper.get_y(fake_data, n_samples)
+        X = self._opener_wrapper.get_X(fake_data, n_fake_samples)
+        y = self._opener_wrapper.get_y(fake_data, n_fake_samples)
 
         # load models
         models = self._load_models(model_names)
@@ -260,10 +260,10 @@ class AlgoWrapper(object):
 
         return model
 
-    def predict(self, model_name, fake_data=False, n_samples=None):
+    def predict(self, model_name, fake_data=False, n_fake_samples=None):
         """Predict method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data, n_samples)
+        X = self._opener_wrapper.get_X(fake_data, n_fake_samples)
 
         # load models
         model = self._load_model(model_name)
@@ -632,11 +632,11 @@ class CompositeAlgoWrapper(AlgoWrapper):
         self._assert_output_model_exists(self._workspace.output_head_model_path, 'head')
 
     def train(self, input_head_model_filename=None, input_trunk_model_filename=None,
-              rank=0, fake_data=False, n_samples=None):
+              rank=0, fake_data=False, n_fake_samples=None):
         """Train method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data, n_samples)
-        y = self._opener_wrapper.get_y(fake_data, n_samples)
+        X = self._opener_wrapper.get_X(fake_data, n_fake_samples)
+        y = self._opener_wrapper.get_y(fake_data, n_fake_samples)
 
         # load head and trunk models
         head_model, trunk_model = self._load_head_trunk_models(
@@ -662,10 +662,10 @@ class CompositeAlgoWrapper(AlgoWrapper):
         return head_model, trunk_model
 
     def predict(self, input_head_model_filename, input_trunk_model_filename,
-                fake_data=False, n_samples=None):
+                fake_data=False, n_fake_samples=None):
         """Predict method wrapper."""
         # load data from opener
-        X = self._opener_wrapper.get_X(fake_data, n_samples)
+        X = self._opener_wrapper.get_X(fake_data, n_fake_samples)
 
         # load head and trunk models
         head_model, trunk_model = self._load_head_trunk_models(

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -307,6 +307,10 @@ def _generate_algo_cli(interface):
             help="Enable fake data mode",
         )
         _parser.add_argument(
+            '--n-fake', default=None, type=int,
+            help="Number of fake samples if fake data is used. Default to the maximum number of samples",
+        )
+        _parser.add_argument(
             '--data-samples-path', default=None,
             help="Define train/test data samples folder path",
         )

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -64,7 +64,7 @@ class Metrics(abc.ABC):
     following command:
 
     ```sh
-    python <script_path> --fake-data --debug
+    python <script_path> --fake-data --n-fake-samples 20 --debug
     ```
 
     To see all the available options for metrics commands, run:
@@ -129,7 +129,7 @@ class MetricsWrapper(object):
         with open(path, 'w') as f:
             json.dump({'all': score}, f)
 
-    def score(self, fake_data=False):
+    def score(self, fake_data=False, n_fake_samples=None):
         """Load labels and predictions and save score results."""
         mode = FakeDataMode.from_value(fake_data)
         if mode == FakeDataMode.DISABLED:
@@ -137,11 +137,11 @@ class MetricsWrapper(object):
             y_pred = self._opener_wrapper.get_predictions()
 
         elif mode == FakeDataMode.FAKE_Y:
-            y = self._opener_wrapper.get_y(fake_data=True)
+            y = self._opener_wrapper.get_y(fake_data=True, n_fake_samples=n_fake_samples)
             y_pred = self._opener_wrapper.get_predictions()
 
         elif mode == FakeDataMode.FAKE_Y_PRED:
-            y = self._opener_wrapper.get_y(fake_data=True)
+            y = self._opener_wrapper.get_y(fake_data=True, n_fake_samples=n_fake_samples)
             y_pred = y
 
         else:
@@ -163,7 +163,11 @@ def _generate_cli():
     parser.add_argument(
         '--fake-data-mode', default=FakeDataMode.DISABLED.name,
         choices=[e.name for e in FakeDataMode],
-        help="Set fake data mode",
+        help="Set fake data )-",
+    )
+    parser.add_argument(
+        '--n-fake-samples', type=int, default=None,
+        help="Number of fake samples if fake data is used.",
     )
     parser.add_argument(
         '--data-samples-path', default=None,
@@ -221,6 +225,8 @@ def execute(interface=None, sysargs=None):
         opener_wrapper=opener_wrapper,
     )
     fake_data = args.fake_data or FakeDataMode.from_str(args.fake_data_mode)
+    n_fake_samples = args.n_fake_samples
     return metrics_wrapper.score(
         fake_data,
+        n_fake_samples,
     )

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -163,7 +163,7 @@ def _generate_cli():
     parser.add_argument(
         '--fake-data-mode', default=FakeDataMode.DISABLED.name,
         choices=[e.name for e in FakeDataMode],
-        help="Set fake data )-",
+        help="Set fake data mode",
     )
     parser.add_argument(
         '--n-fake-samples', type=int, default=None,

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -9,7 +9,14 @@ from substratools.workspace import OpenerWorkspace
 logger = logging.getLogger(__name__)
 
 
-REQUIRED_FUNCTIONS = set(["get_X", "get_y", "fake_X", "fake_y", "get_predictions", "save_predictions", ])
+REQUIRED_FUNCTIONS = set([
+    'get_X',
+    'get_y',
+    'fake_X',
+    'fake_y',
+    'get_predictions',
+    'save_predictions',
+])
 
 
 class Opener(abc.ABC):
@@ -167,7 +174,8 @@ class OpenerWrapper(object):
     """Internal wrapper to call opener interface."""
 
     def __init__(self, interface, workspace=None):
-        assert isinstance(interface, Opener) or isinstance(interface, types.ModuleType)
+        assert isinstance(interface, Opener) or \
+            isinstance(interface, types.ModuleType)
 
         self._workspace = workspace or OpenerWorkspace()
         self._interface = interface
@@ -175,11 +183,9 @@ class OpenerWrapper(object):
     @property
     def data_folder_paths(self):
         rootpath = self._workspace.input_data_folder_path
-        folders = [
-            os.path.join(rootpath, subfolder_name)
-            for subfolder_name in os.listdir(rootpath)
-            if os.path.isdir(os.path.join(rootpath, subfolder_name))
-        ]
+        folders = [os.path.join(rootpath, subfolder_name)
+                   for subfolder_name in os.listdir(rootpath)
+                   if os.path.isdir(os.path.join(rootpath, subfolder_name))]
         return folders
 
     def get_X(self, fake_data=False, n_fake_samples=None):
@@ -206,9 +212,9 @@ class OpenerWrapper(object):
     def _assert_predictions_file_exists(self):
         path = self._workspace.output_predictions_path
         if os.path.isdir(path):
-            raise exceptions.NotAFileError(f"Expected predictions file at {path}, found dir")
+            raise exceptions.NotAFileError(f'Expected predictions file at {path}, found dir')
         if not os.path.isfile(path):
-            raise exceptions.MissingFileError(f"Predictions file {path} does not exists")
+            raise exceptions.MissingFileError(f'Predictions file {path} does not exists')
 
     def save_predictions(self, y_pred):
         path = self._workspace.output_predictions_path
@@ -226,7 +232,7 @@ def load_from_module(path=None, workspace=None):
     Return an OpenerWrapper instance.
     """
     interface = utils.load_interface_from_module(
-        "opener",
+        'opener',
         interface_class=Opener,
         interface_signature=None,  # XXX does not support interface for debugging
         path=path,

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -55,10 +55,10 @@ class Opener(abc.ABC):
                 for folder in folders
             ]
 
-        def fake_X(self, n_samples=None):
+        def fake_X(self, n_fake_samples=None):
             return []  # compute random fake data
 
-        def fake_y(self, n_samples=None):
+        def fake_y(self, n_fake_samples=None):
             return []  # compute random fake data
 
         def save_predictions(self, y_pred, path):
@@ -117,12 +117,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         """Generate a fake matrix of features for offline testing.
 
         # Arguments
 
-        n_samples: number of samples to return, all by default
+        n_fake_samples: number of samples to return, all by default
 
         # Returns
 
@@ -131,12 +131,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         """Generate a fake target variable vector for offline testing.
 
         # Arguments
 
-        n_samples: number of samples to return, all by default
+        n_fake_samples: number of samples to return, all by default
 
         # Returns
 
@@ -188,18 +188,18 @@ class OpenerWrapper(object):
                    if os.path.isdir(os.path.join(rootpath, subfolder_name))]
         return folders
 
-    def get_X(self, fake_data=False, n_samples=None):
+    def get_X(self, fake_data=False, n_fake_samples=None):
         if fake_data:
             logger.info("loading X from fake data")
-            return self._interface.fake_X(n_samples=n_samples)
+            return self._interface.fake_X(n_fake_samples=n_fake_samples)
         else:
             logger.info("loading X from '{}'".format(self.data_folder_paths))
             return self._interface.get_X(self.data_folder_paths)
 
-    def get_y(self, fake_data=False, n_samples=None):
+    def get_y(self, fake_data=False, n_fake_samples=None):
         if fake_data:
             logger.info("loading y from fake data")
-            return self._interface.fake_y(n_samples=n_samples)
+            return self._interface.fake_y(n_fake_samples=n_fake_samples)
         else:
             logger.info("loading y from '{}'".format(self.data_folder_paths))
             return self._interface.get_y(self.data_folder_paths)

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -115,7 +115,7 @@ class Opener(abc.ABC):
 
         # Arguments
 
-        n_samples: number of samples to return, all by default
+        n_samples: number of samples to return
 
         # Returns
 
@@ -129,7 +129,7 @@ class Opener(abc.ABC):
 
         # Arguments
 
-        n_samples: number of samples to return, all by default
+        n_samples: number of samples to return
 
         # Returns
 

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -55,10 +55,10 @@ class Opener(abc.ABC):
                 for folder in folders
             ]
 
-        def fake_X(self):
+        def fake_X(self, n_samples=None):
             return []  # compute random fake data
 
-        def fake_y(self):
+        def fake_y(self, n_samples=None):
             return []  # compute random fake data
 
         def save_predictions(self, y_pred, path):

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -9,14 +9,7 @@ from substratools.workspace import OpenerWorkspace
 logger = logging.getLogger(__name__)
 
 
-REQUIRED_FUNCTIONS = set([
-    'get_X',
-    'get_y',
-    'fake_X',
-    'fake_y',
-    'get_predictions',
-    'save_predictions',
-])
+REQUIRED_FUNCTIONS = set(["get_X", "get_y", "fake_X", "fake_y", "get_predictions", "save_predictions", ])
 
 
 class Opener(abc.ABC):
@@ -55,10 +48,10 @@ class Opener(abc.ABC):
                 for folder in folders
             ]
 
-        def fake_X(self, n_fake_samples=None):
+        def fake_X(self, n_samples=None):
             return []  # compute random fake data
 
-        def fake_y(self, n_fake_samples=None):
+        def fake_y(self, n_samples=None):
             return []  # compute random fake data
 
         def save_predictions(self, y_pred, path):
@@ -117,12 +110,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         """Generate a fake matrix of features for offline testing.
 
         # Arguments
 
-        n_fake_samples: number of samples to return, all by default
+        n_samples: number of samples to return, all by default
 
         # Returns
 
@@ -131,12 +124,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         """Generate a fake target variable vector for offline testing.
 
         # Arguments
 
-        n_fake_samples: number of samples to return, all by default
+        n_samples: number of samples to return, all by default
 
         # Returns
 
@@ -174,8 +167,7 @@ class OpenerWrapper(object):
     """Internal wrapper to call opener interface."""
 
     def __init__(self, interface, workspace=None):
-        assert isinstance(interface, Opener) or \
-            isinstance(interface, types.ModuleType)
+        assert isinstance(interface, Opener) or isinstance(interface, types.ModuleType)
 
         self._workspace = workspace or OpenerWorkspace()
         self._interface = interface
@@ -183,15 +175,17 @@ class OpenerWrapper(object):
     @property
     def data_folder_paths(self):
         rootpath = self._workspace.input_data_folder_path
-        folders = [os.path.join(rootpath, subfolder_name)
-                   for subfolder_name in os.listdir(rootpath)
-                   if os.path.isdir(os.path.join(rootpath, subfolder_name))]
+        folders = [
+            os.path.join(rootpath, subfolder_name)
+            for subfolder_name in os.listdir(rootpath)
+            if os.path.isdir(os.path.join(rootpath, subfolder_name))
+        ]
         return folders
 
     def get_X(self, fake_data=False, n_fake_samples=None):
         if fake_data:
             logger.info("loading X from fake data")
-            return self._interface.fake_X(n_fake_samples=n_fake_samples)
+            return self._interface.fake_X(n_samples=n_fake_samples)
         else:
             logger.info("loading X from '{}'".format(self.data_folder_paths))
             return self._interface.get_X(self.data_folder_paths)
@@ -199,7 +193,7 @@ class OpenerWrapper(object):
     def get_y(self, fake_data=False, n_fake_samples=None):
         if fake_data:
             logger.info("loading y from fake data")
-            return self._interface.fake_y(n_fake_samples=n_fake_samples)
+            return self._interface.fake_y(n_samples=n_fake_samples)
         else:
             logger.info("loading y from '{}'".format(self.data_folder_paths))
             return self._interface.get_y(self.data_folder_paths)
@@ -212,9 +206,9 @@ class OpenerWrapper(object):
     def _assert_predictions_file_exists(self):
         path = self._workspace.output_predictions_path
         if os.path.isdir(path):
-            raise exceptions.NotAFileError(f'Expected predictions file at {path}, found dir')
+            raise exceptions.NotAFileError(f"Expected predictions file at {path}, found dir")
         if not os.path.isfile(path):
-            raise exceptions.MissingFileError(f'Predictions file {path} does not exists')
+            raise exceptions.MissingFileError(f"Predictions file {path} does not exists")
 
     def save_predictions(self, y_pred):
         path = self._workspace.output_predictions_path
@@ -232,7 +226,7 @@ def load_from_module(path=None, workspace=None):
     Return an OpenerWrapper instance.
     """
     interface = utils.load_interface_from_module(
-        'opener',
+        "opener",
         interface_class=Opener,
         interface_signature=None,  # XXX does not support interface for debugging
         path=path,

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -117,8 +117,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         """Generate a fake matrix of features for offline testing.
+
+        # Arguments
+
+        n_samples: number of samples to return, all by default
 
         # Returns
 
@@ -127,8 +131,12 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         """Generate a fake target variable vector for offline testing.
+
+        # Arguments
+
+        n_samples: number of samples to return, all by default
 
         # Returns
 
@@ -180,18 +188,18 @@ class OpenerWrapper(object):
                    if os.path.isdir(os.path.join(rootpath, subfolder_name))]
         return folders
 
-    def get_X(self, fake_data=False):
+    def get_X(self, fake_data=False, n_samples=None):
         if fake_data:
             logger.info("loading X from fake data")
-            return self._interface.fake_X()
+            return self._interface.fake_X(n_samples=n_samples)
         else:
             logger.info("loading X from '{}'".format(self.data_folder_paths))
             return self._interface.get_X(self.data_folder_paths)
 
-    def get_y(self, fake_data=False):
+    def get_y(self, fake_data=False, n_samples=None):
         if fake_data:
             logger.info("loading y from fake data")
-            return self._interface.fake_y()
+            return self._interface.fake_y(n_samples=n_samples)
         else:
             logger.info("loading y from '{}'".format(self.data_folder_paths))
             return self._interface.get_y(self.data_folder_paths)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,10 @@ class FakeOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         return 'Xfake'
 
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,13 @@ class FakeOpener(Opener):
         return list(range(0, 3))
 
     def fake_X(self, n_samples=None):
+        if n_samples:
+            return ['Xfake'] * n_samples
         return 'Xfake'
 
     def fake_y(self, n_samples=None):
+        if n_samples:
+            return [0] * n_samples
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,14 +34,14 @@ class FakeOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self, n_fake_samples=None):
-        if n_fake_samples:
-            return ['Xfake'] * n_fake_samples
+    def fake_X(self, n_samples=None):
+        if n_samples:
+            return ['Xfake'] * n_samples
         return 'Xfake'
 
-    def fake_y(self, n_fake_samples=None):
-        if n_fake_samples:
-            return [0] * n_fake_samples
+    def fake_y(self, n_samples=None):
+        if n_samples:
+            return [0] * n_samples
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,14 +34,14 @@ class FakeOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self, n_samples=None):
-        if n_samples:
-            return ['Xfake'] * n_samples
+    def fake_X(self, n_fake_samples=None):
+        if n_fake_samples:
+            return ['Xfake'] * n_fake_samples
         return 'Xfake'
 
-    def fake_y(self, n_samples=None):
-        if n_samples:
-            return [0] * n_samples
+    def fake_y(self, n_fake_samples=None):
+        if n_fake_samples:
+            return [0] * n_fake_samples
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -94,21 +94,21 @@ def test_train_multiple_models(workdir, create_models):
 def test_train_fake_data():
     a = DummyAlgo()
     wp = algo.AlgoWrapper(a)
-    model = wp.train([], fake_data=True, n_samples=2)
+    model = wp.train([], fake_data=True, n_fake_samples=2)
     assert model['value'] == 0
 
 
-@pytest.mark.parametrize("fake_data,expected_pred,n_samples", [
+@pytest.mark.parametrize("fake_data,expected_pred,n_fake_samples", [
     (False, 'X', None),
     (True, ['Xfake'], 1),
     (True, 'Xfake', None),
 ])
-def test_predict(fake_data, expected_pred, n_samples, workdir, create_models):
+def test_predict(fake_data, expected_pred, n_fake_samples, workdir, create_models):
     _, model_filenames = create_models
 
     a = DummyAlgo()
     wp = algo.AlgoWrapper(a)
-    pred = wp.predict(model_filenames[0], fake_data=fake_data, n_samples=n_samples)
+    pred = wp.predict(model_filenames[0], fake_data=fake_data, n_fake_samples=n_fake_samples)
     assert pred == expected_pred
 
 

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -94,20 +94,21 @@ def test_train_multiple_models(workdir, create_models):
 def test_train_fake_data():
     a = DummyAlgo()
     wp = algo.AlgoWrapper(a)
-    model = wp.train([], fake_data=True)
+    model = wp.train([], fake_data=True, n_samples=2)
     assert model['value'] == 0
 
 
-@pytest.mark.parametrize("fake_data,expected_pred", [
-    (False, 'X'),
-    (True, 'Xfake'),
+@pytest.mark.parametrize("fake_data,expected_pred,n_samples", [
+    (False, 'X', None),
+    (True, ['Xfake'], 1),
+    (True, 'Xfake', None),
 ])
-def test_predict(fake_data, expected_pred, workdir, create_models):
+def test_predict(fake_data, expected_pred, n_samples, workdir, create_models):
     _, model_filenames = create_models
 
     a = DummyAlgo()
     wp = algo.AlgoWrapper(a)
-    pred = wp.predict(model_filenames[0], fake_data=fake_data)
+    pred = wp.predict(model_filenames[0], fake_data=fake_data, n_samples=n_samples)
     assert pred == expected_pred
 
 
@@ -119,7 +120,7 @@ def test_execute_train(workdir):
     algo.execute(DummyAlgo(), sysargs=['train'])
     assert output_model_path.exists()
 
-    algo.execute(DummyAlgo(), sysargs=['train', '--fake-data'])
+    algo.execute(DummyAlgo(), sysargs=['train', '--fake-data', '--n-fake-samples', '1'])
     assert output_model_path.exists()
 
     algo.execute(DummyAlgo(), sysargs=['train', '--debug'])

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -49,9 +49,9 @@ def get_X(folders):
     return 'X'
 def get_y(folders):
     return 'y'
-def fake_X(n_samples=None):
+def fake_X(n_fake_samples=None):
     return 'fakeX'
-def fake_y(n_samples=None):
+def fake_y(n_fake_samples=None):
     return 'fakey'
 def get_predictions(path):
     return 'pred'
@@ -73,9 +73,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         return 'fakeX'
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -107,9 +107,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         return 'fakeX'
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -151,10 +151,10 @@ class MyOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         return 'Xfake'
 
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -49,9 +49,9 @@ def get_X(folders):
     return 'X'
 def get_y(folders):
     return 'y'
-def fake_X():
+def fake_X(n_samples=None):
     return 'fakeX'
-def fake_y():
+def fake_y(n_samples=None):
     return 'fakey'
 def get_predictions(path):
     return 'pred'
@@ -73,9 +73,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         return 'fakeX'
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -107,9 +107,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         return 'fakeX'
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -151,10 +151,10 @@ class MyOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         return 'Xfake'
 
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -49,9 +49,9 @@ def get_X(folders):
     return 'X'
 def get_y(folders):
     return 'y'
-def fake_X(n_fake_samples=None):
+def fake_X(n_samples=None):
     return 'fakeX'
-def fake_y(n_fake_samples=None):
+def fake_y(n_samples=None):
     return 'fakey'
 def get_predictions(path):
     return 'pred'
@@ -73,9 +73,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         return 'fakeX'
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -107,9 +107,9 @@ class MyOpener(Opener):
         return 'Xclass'
     def get_y(self, folders):
         return 'yclass'
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         return 'fakeX'
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         return 'fakey'
     def get_predictions(self, path):
         return 'pred'
@@ -151,10 +151,10 @@ class MyOpener(Opener):
     def get_y(self, folder):
         return list(range(0, 3))
 
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         return 'Xfake'
 
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         return [0] * 3
 
     def get_predictions(self, path):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,10 +23,10 @@ class DummyOpener(Opener):
     def get_y(self, folder):
         return None
 
-    def fake_X(self, n_fake_samples=None):
+    def fake_X(self, n_samples=None):
         raise NotImplementedError
 
-    def fake_y(self, n_fake_samples=None):
+    def fake_y(self, n_samples=None):
         raise NotImplementedError
 
     def get_predictions(self, path):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,10 +23,10 @@ class DummyOpener(Opener):
     def get_y(self, folder):
         return None
 
-    def fake_X(self):
+    def fake_X(self, n_samples=None):
         raise NotImplementedError
 
-    def fake_y(self):
+    def fake_y(self, n_samples=None):
         raise NotImplementedError
 
     def get_predictions(self, path):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,10 +23,10 @@ class DummyOpener(Opener):
     def get_y(self, folder):
         return None
 
-    def fake_X(self, n_samples=None):
+    def fake_X(self, n_fake_samples=None):
         raise NotImplementedError
 
-    def fake_y(self, n_samples=None):
+    def fake_y(self, n_fake_samples=None):
         raise NotImplementedError
 
     def get_predictions(self, path):


### PR DESCRIPTION
Add the option to choose the number of samples when generating fake data. 
This breaks existing code from the users (their opener.py), at least the `fake_X` and `fake_y` functions.

PR on substra: https://github.com/SubstraFoundation/substra/pull/194
