### PR TITLE
add Dockerfile.minimal

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:9.2-base-ubuntu18.04
+
+ADD ./setup.py /tmp
+ADD ./substratools /tmp/substratools
+ADD ./README.md /tmp
+
+RUN apt-get update; \
+    apt-get install -y python3-minimal python3-pip; \
+    cd /tmp && pip3 install . ; \
+    apt-get remove -y python3-pip --purge --autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/
+
+RUN mkdir -p /sandbox
+ENV PYTHONPATH /sandbox
+
+WORKDIR /sandbox

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:9.2-base-ubuntu18.04
 
 ADD ./setup.py /tmp
-ADD ./substratools /tmp/substratools
 ADD ./README.md /tmp
+ADD ./substratools /tmp/substratools
 
 RUN apt-get update; \
     apt-get install -y python3-minimal python3-pip; \
@@ -11,7 +11,5 @@ RUN apt-get update; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/
 
-RUN mkdir -p /sandbox
-ENV PYTHONPATH /sandbox
-
 WORKDIR /sandbox
+ENV PYTHONPATH /sandbox


### PR DESCRIPTION
Add a minimal Docker image, with only contains `python3` and `substratools`.

```
substrafoundation/substra-tools    0.6.0             434a538803a9     7 days ago       858MB
substrafoundation/substra-tools    0.6.0-minimal     e39e8d38e26d     13 hours ago     126MB
```


The main goal of this PR is to speed up local development, especially for slower connections.

The performance boost in the backend is not measurably significant for fast connections, although we should see a faster prepopulate, and generally less moving of bytes, which can only have positive effects (L1/2/3 disk cache, disk usage, RAM usage, etc)

Companion PRs:

- https://github.com/SubstraFoundation/substra-tests/pull/118


# Merge checklist

- [ ] Push the minimal image to Dockerhub
