### PR TITLE
Update twine before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ deploy:
   distributions: 'sdist bdist_wheel'
   on:
     tags: true
+  before_deploy:
+    - pip install -U twine wheel setuptools
 
 script:
   - pip install flake8


### PR DESCRIPTION
Attempt to fix build https://travis-ci.org/github/SubstraFoundation/substra-tools/builds/742712777

This looks like it's related to this change in pypa: https://github.com/pypa/warehouse/issues/5890#issuecomment-494868157

Since we already have `long_description_content_type="text/markdown",` in our `setup.py`, the only course of action is to update twine / wheel / setuptools as suggested in the issue.

Once merge, tag 0.7.0 will have to be deleted and re-created.